### PR TITLE
feat: full conversion to runes and a few bug fixes

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,6 @@
 		"@sveltejs/vite-plugin-svelte": "^6.1.3",
 		"@tailwindcss/postcss": "^4.1.12",
 		"@types/node": "^24.3.0",
-		"@zerodevx/svelte-toast": "0.9.6",
 		"axios": "^1.11.0",
 		"flowbite": "^3.1.2",
 		"flowbite-svelte": "^1.12.6",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -26,9 +26,6 @@ importers:
       '@types/node':
         specifier: ^24.3.0
         version: 24.3.0
-      '@zerodevx/svelte-toast':
-        specifier: 0.9.6
-        version: 0.9.6(svelte@5.38.2)
       axios:
         specifier: ^1.11.0
         version: 1.11.0
@@ -571,11 +568,6 @@ packages:
 
   '@yr/monotone-cubic-spline@1.0.3':
     resolution: {integrity: sha512-FQXkOta0XBSUPHndIKON2Y9JeQz5ZeMqLYZVVK93FliNBFm7LNMIZmY6FrMEB9XPcDbE2bekMbZD6kzDkxwYjA==}
-
-  '@zerodevx/svelte-toast@0.9.6':
-    resolution: {integrity: sha512-nHlTrCjverlPK9yukK6fqbG3e/R+f10ldrc4nJHOe2qNDScuPTuYVSFEk2dDDtzWAwTN5pmdEXgA3M2RbT8jiw==}
-    peerDependencies:
-      svelte: ^3.57.0 || ^4.0.0 || ^5.0.0
 
   acorn@8.14.1:
     resolution: {integrity: sha512-OvQ/2pUDKmgfCg++xsTX1wGxfTaszcHVcTctW4UJB4hibJx2HXxxO5UmVgyjMa+ZDsiaf5wWLXYpRWMmBI0QHg==}
@@ -1545,10 +1537,6 @@ snapshots:
   '@types/resolve@1.20.2': {}
 
   '@yr/monotone-cubic-spline@1.0.3': {}
-
-  '@zerodevx/svelte-toast@0.9.6(svelte@5.38.2)':
-    dependencies:
-      svelte: 5.38.2
 
   acorn@8.14.1: {}
 

--- a/src/lib/components/EditMobDataModal.svelte
+++ b/src/lib/components/EditMobDataModal.svelte
@@ -3,7 +3,7 @@
     import { createEventDispatcher } from 'svelte';
     import { Accordion, AccordionItem } from 'flowbite-svelte';
 
-    export let selectedMob: IMobData | null = null;
+    let { selectedMob = null } = $props<{ selectedMob?: IMobData | null }>();
     const dispatch = createEventDispatcher();
 
     function closeModal() {

--- a/src/lib/components/FeatureCard.svelte
+++ b/src/lib/components/FeatureCard.svelte
@@ -1,11 +1,13 @@
 <script lang="ts">
     import { Card, Button } from 'flowbite-svelte';
     import { ArrowRightOutline } from 'flowbite-svelte-icons';
-    export let title: string = "title";
-    export let target: string = "_blank";
-    export let description: string = "description";
-    export let link: string = "#";
-    export let linkText: string = "Read more";
+    let { 
+        title = "title",
+        target = "_blank",
+        description = "description",
+        link = "#",
+        linkText = "Read more"
+    } = $props<{ title?: string; target?: string; description?: string; link?: string; linkText?: string }>();
 </script>
 
 <Card class="p-4 sm:p-6 md:p-8">

--- a/src/lib/components/FilterPanel.svelte
+++ b/src/lib/components/FilterPanel.svelte
@@ -8,8 +8,8 @@
     }>();
     
     // Filter state
-    let isExpanded = false;
-    let filter: GearFilter = {
+    let isExpanded = $state(false);
+    let filter: GearFilter = $state({
         name: '',
         typeName: '',
         rarity: undefined,
@@ -21,7 +21,7 @@
         affixName: '',
         affixMinTier: undefined,
         affixMinValue: undefined
-    };
+    });
     
     // Item types (placeholder - replace with actual types from backend)
     const itemTypes = [

--- a/src/lib/components/Header.svelte
+++ b/src/lib/components/Header.svelte
@@ -24,28 +24,24 @@
     let userService = new UserService();
     const isDebug = import.meta.env.VITE_DEBUG === 'true';
 
-    let currentUser: IUser;
-    let settingsOpen = false;
+    let currentUser: IUser | null = $state(null);
+    let settingsOpen = $state(false);
 
-    // Determine if we're on the home page
-    $: isHome = $page.url?.pathname === '/';
+    // Determine if we're on the home page (runes)
+    let isHome = $derived($page?.url?.pathname === '/');
 
-    // Classes depending on route
-    $: navbarClass = isHome
-        ? 'bg-transparent fixed top-0 left-0 right-0 z-50 backdrop-blur-sm'
-        : 'bg-primary-100 dark:bg-primary-700';
+    // Classes depending on route (runes)
+    let navbarClass = $derived(
+        isHome
+            ? 'bg-transparent fixed top-0 left-0 right-0 z-50 backdrop-blur-sm'
+            : 'bg-primary-100 dark:bg-primary-700'
+    );
 
-    $: brandTextClass = isHome
-        ? 'text-white'
-        : 'text-primary-700';
+    let brandTextClass = $derived(isHome ? 'text-white' : 'text-primary-700');
 
-    $: navLinkClass = isHome
-        ? 'text-white hover:text-gray-200'
-        : '';
+    let navLinkClass = $derived(isHome ? 'text-white hover:text-gray-200' : '');
 
-    $: hamburgerClass = isHome
-        ? 'text-white'
-        : '';
+    let hamburgerClass = $derived(isHome ? 'text-white' : '');
 
     const unsubscribe = user.subscribe(value => {
         // @ts-ignore

--- a/src/lib/components/LoginModal.svelte
+++ b/src/lib/components/LoginModal.svelte
@@ -1,17 +1,17 @@
 <script lang="ts">
     import {Button, Modal, Label, Input} from 'flowbite-svelte';
 
-    let modalOpen = false;
+    let modalOpen = $state(false);
 
     import {UserService} from "$lib/services/user-service";
-    import {toast} from '@zerodevx/svelte-toast'
+    import { toast } from '$lib/toast'
 
     let userService = new UserService();
 
-    let email = "";
-    let password = "";
-    let profileName = "";
-    let view = "login";
+    let email = $state("");
+    let password = $state("");
+    let profileName = $state("");
+    let view = $state("login");
 
     async function signup() {
         await userService.signup(email, password, profileName);
@@ -30,7 +30,7 @@
 </script>
 
 <Button onclick={() => (modalOpen = true)}>Login</Button>
-<form on:submit={async (e) => {
+<form onsubmit={async (e) => {
    if (view === 'login') {
        await login();
     } else if (view === 'register') {
@@ -39,8 +39,8 @@
         await forgotPassword();
     }
 }}>
-    <Modal title="Login / Signup" bind:open={modalOpen} autoclose={false}>
-        { #if view === 'register'}
+    <Modal title="Login / Signup" bind:open={modalOpen} autoclose={false} form>
+        {#if view === 'register'}
             <div class="mb-4">
                 <Label for="small-input" class="block mb-2">Profile Name</Label>
                 <Input id="small-input" size="sm" placeholder="DrBibbityBob" bind:value={profileName}/>
@@ -50,13 +50,13 @@
             <Label for="small-input" class="block mb-2">Email</Label>
             <Input id="small-input" size="sm" placeholder="imsocool@example.com" bind:value={email}/>
         </div>
-        { #if view !== 'forgot-password'}
+        {#if view !== 'forgot-password'}
             <div class="mb-6">
                 <Label for="small-input" class="block mb-2">Password</Label>
                 <Input type="password" id="small-input" size="sm" placeholder="password123" bind:value={password}/>
             </div>
         {/if}
-        <svelte:fragment slot="footer">
+        {#snippet footer()}
             <div class="flex justify-between w-full">
                 <div class="inline-flex">
                     <Button color="alternative" onclick={() => view = 'forgot-password'}>
@@ -64,7 +64,7 @@
                     </Button>
                 </div>
                 <div class="inline-flex">
-                    {#if view === 'login' }
+                    {#if view === 'login'}
                         <Button color="alternative" onclick={() => view = 'register'}>
                             Register Instead
                         </Button>
@@ -88,6 +88,6 @@
                     {/if}
                 </div>
             </div>
-        </svelte:fragment>
+        {/snippet}
     </Modal>
 </form>

--- a/src/lib/components/SettingsModal.svelte
+++ b/src/lib/components/SettingsModal.svelte
@@ -1,20 +1,14 @@
 <script lang="ts">
     import {Button, Modal, Label, Input, DropdownItem} from 'flowbite-svelte';
 
-    export let open = false;
-    export let currentUser: IUser;
+    let { open = $bindable(false), currentUser = $bindable(undefined as unknown as IUser) } = $props<{ open: boolean; currentUser: IUser }>();
 
     import {UserService} from "$lib/services/user-service";
-    import {toast} from "@zerodevx/svelte-toast";
+    import { toast } from "$lib/toast";
     import type {IUser} from "$lib/stores/user-store";
     import steamSignin from "$lib/images/steam-signin.png";
 
     let userService = new UserService();
-
-    let email = ""
-    let password = ""
-    let profileName = ""
-    let view = "login";
 
     async function updateUser() {
         await userService.updateProfile(currentUser.profileName);
@@ -26,12 +20,13 @@
         await userService.unlinkSteam();
         toast.push("Steam Account Unlinked");
     }
+
 </script>
 
-<form on:submit={async (e) => {
+<form onsubmit={async (e) => {
    await updateUser();
 }}>
-    <Modal title="Settings" bind:open={open} autoclose={false}>
+    <Modal title="Settings" bind:open={open} autoclose={false} form>
         <div class="mb-9">
             <Label for="small-input" class="block mb-2">Profile Name</Label>
             <Input id="small-input" size="sm" placeholder="DrBibbityBob" bind:value={currentUser.profileName}/>
@@ -41,7 +36,7 @@
             <a href="{import.meta.env.VITE_API_BASE_URL}LoginWithSteam?userId={currentUser.id}">
                 <img src={steamSignin} alt="steam signing">
             </a>
-        {:else }
+        {:else}
             <span class="block text-sm">
                 Steam Account {currentUser.steamId} Linked
                 <Button class="block" type="button" onclick={() => unlinkSteam()}>
@@ -49,12 +44,13 @@
                 </Button>
             </span>
         {/if}
-        <svelte:fragment slot="footer">
+
+        {#snippet footer()}
             <div class="text-right">
                 <Button type="submit">
                     Update
                 </Button>
             </div>
-        </svelte:fragment>
+        {/snippet}
     </Modal>
 </form>

--- a/src/lib/components/TradeListing.svelte
+++ b/src/lib/components/TradeListing.svelte
@@ -1,14 +1,14 @@
 <script lang="ts">
     import {type ITradeListing, TradeListingItemDataRarity} from "$lib/models/trade-listing";
     import placeholder from '$lib/images/item-placeholder.png';
-    import {toast} from "@zerodevx/svelte-toast";
+    import { toast } from "$lib/toast";
     import {UserService} from "$lib/services/user-service";
     import {TradeListingService} from "$lib/services/trade-listing-service";
 
     let userService = new UserService();
     let tradeListingService = new TradeListingService();
 
-    export let listing: ITradeListing;
+    let { listing } = $props<{ listing: ITradeListing }>();
 
     const currencyNames = [
         "Glittering Shard", // GlitteringShard = 0

--- a/src/lib/services/http-service.ts
+++ b/src/lib/services/http-service.ts
@@ -1,6 +1,6 @@
 import axios, {type AxiosRequestConfig, type AxiosResponse} from 'axios';
 import { GetJwtToken } from './session-service';
-import { toast } from "@zerodevx/svelte-toast";
+import { toast } from "$lib/toast";
 
 export class HttpService {
     private static instance: HttpService;

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -1,20 +1,15 @@
 <script>
 	import Header from '$lib/components/Header.svelte';
 	import './styles.css';
-	import {SvelteToast} from "@zerodevx/svelte-toast";
+	import Toaster from '$lib/components/Toaster.svelte';
 	export const ssr = false;
 	export const prerender = true;
 	export const trailingSlash = 'always';
-	let options = {
-		duration: 5000,
-		position: 'top-right',
-		type: 'success',
-	};
 </script>
-<SvelteToast {options} />
+<Toaster />
 <div class="app">
 	<Header />
-
+	
 	<main>
 		<slot />
 	</main>

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
 	import { Heading } from "flowbite-svelte";
 	import { onMount } from 'svelte';
-	import { toast } from '@zerodevx/svelte-toast';
+ import { toast } from '$lib/toast';
 	import { WandMagicSparklesSolid, AnnotationSolid, MapPinAltSolid, AdjustmentsVerticalSolid } from 'flowbite-svelte-icons';
 
 	import { user } from "$lib/stores/user-store";

--- a/src/routes/admin/Users/+page.svelte
+++ b/src/routes/admin/Users/+page.svelte
@@ -5,19 +5,19 @@
     import type {IUser} from "$lib/stores/user-store";
     
     let userService = new UserService();
-    let profileName = "";
-    let user: IUser | null = null;
-    let loading = false;
-    let error = "";
-    let saveLoading = false;
-    let saveSuccess = false;
-    let saveError = "";
+    let profileName = $state("");
+    let user: IUser | null = $state(null);
+    let loading = $state(false);
+    let error = $state("");
+    let saveLoading = $state(false);
+    let saveSuccess = $state(false);
+    let saveError = $state("");
     
     // Available roles
     const availableRoles = ["ViewAdminPanel", "EditTranslations"];
     
     // Selected roles
-    let selectedRoles: string[] = [];
+    let selectedRoles: string[] = $state([]);
     
     async function searchUser() {
         if (!profileName.trim()) {

--- a/src/routes/mod-data/localization/+page.svelte
+++ b/src/routes/mod-data/localization/+page.svelte
@@ -3,7 +3,7 @@
     import {TranslationEntryService} from '$lib/services/translation-entry-service';
     import {HjsonParserService} from '$lib/services/hjson-parser-service';
     import type {IEnglishTranslation, ITranslationEntry} from '$lib/models/localization';
-    import {toast} from '@zerodevx/svelte-toast';
+    import { toast } from '$lib/toast';
     import {UserService} from '$lib/services/user-service';
     import {IsLoggedIn} from "$lib/services/session-service";
 

--- a/src/routes/profile/[slug]/characters/+page.svelte
+++ b/src/routes/profile/[slug]/characters/+page.svelte
@@ -5,7 +5,7 @@
     import {UserService} from "$lib/services/user-service";
     let userService = new UserService();
     let playerService = new PlayerService();
-    import {toast} from "@zerodevx/svelte-toast";
+    import { toast } from "$lib/toast";
 
     let { data }: { data: PageData } = $props();
 
@@ -97,7 +97,8 @@
     <p class="text-base leading-relaxed text-gray-500 dark:text-gray-400">
         Are you sure you want to delete {playerNameToDelete}? This action cannot be undone.
     </p>
-    <svelte:fragment slot="footer">
+
+    {#snippet footer()}
         <div class="flex justify-end w-full">
             <Button color="alternative" onclick={() => deleteModalOpen = false} class="mr-6">
                 Cancel
@@ -106,5 +107,5 @@
                 Delete
             </Button>
         </div>
-    </svelte:fragment>
+    {/snippet}
 </Modal>

--- a/src/routes/reset-password/+page.svelte
+++ b/src/routes/reset-password/+page.svelte
@@ -2,7 +2,7 @@
     import { Heading, Label, Input, Button } from 'flowbite-svelte';
 
     import {UserService} from "$lib/services/user-service";
-    import { toast } from '@zerodevx/svelte-toast'
+    import { toast } from '$lib/toast'
     import {onMount} from "svelte";
     import {goto} from "$app/navigation";
 

--- a/svelte.config.js
+++ b/svelte.config.js
@@ -7,6 +7,10 @@ const config = {
 	// for more information about preprocessors
 	preprocess: vitePreprocess(),
 
+	compilerOptions: {
+		runes: true
+	},
+
 	kit: {
 		// adapter-auto only supports some environments, see https://kit.svelte.dev/docs/adapter-auto for a list.
 		// If your environment is not supported, or you settled on a specific environment, switch out the adapter.


### PR DESCRIPTION
* Convert project to use the new Svelte Runes
* Removal of toast plugin that does not support new Svelte Runes
* Fixes the bug where modals would be submitted when closing due to a Flowbite change
* Fixes footer snippets for modals `<svelte:fragment` -> `<#snippet>`
* Updates a few dated `on:submit` events to `onsubmit` for new svelte "preferred" way of events